### PR TITLE
Update default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,15 @@
 { pkgs ? import <nixpkgs> {}
-, src ? ./.
-, version ? "git"
-, ... }:
+, trivialBuild ? pkgs.emacsPackages.trivialBuild
+# user arguments
+, packageSrc ? ./.
+, packageVersion ? "git"
+}:
 
-pkgs.emacsPackages.trivialBuild rec {
+trivialBuild rec {
   pname = "emacs-webkit";
-  inherit src version;
+
+  src = packageSrc;
+  version = packageVersion;
 
   buildPhase = ''
     make all


### PR DESCRIPTION
More idiomatic `callPackage`-ing from any `emacsPackages` set, including generated ones.

I chose to rename `src` and `version` due to an `src` attribute already existing in `pkgs`, which would lead to it being passed as an argument if `emacsPackages.callPackage` was called on it. I'd honestly like to remove the arguments, but I imagine you have them in place for a reason so I won't mess with them without a :+1: from you.

Closes #29.