### PR TITLE
Require ol.el

### DIFF
--- a/webkit.el
+++ b/webkit.el
@@ -25,6 +25,9 @@
 
 ;;; Code:
 
+;; ol is an unmentioned dependency
+(require 'ol)
+
 ;; Don't require dynamic module at byte compile time.
 ;; Generate this list with:
 ;; awk -F\" '/mkfn*/ {print "(declare-function", $2, "\"webkit-module\")"}' webkit-module.c


### PR DESCRIPTION
ol.el is an unmentioned dependency, I'm not very experienced with elisp but I think this should work?

Fixes the following:
https://github.com/akirakyle/emacs-webkit/issues/23
https://github.com/akirakyle/emacs-webkit/issues/32